### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ To get started scripting, download the [ThousandEyes Recorder](https://app.thous
 * MacOS - MacOS 10.10 (Yosemite) or later - [Download - Mac dmg](https://downloads.thousandeyes.com/tedit/recorder/ThousandEyesRecorderIDE.dmg)
 * Linux - Ubuntu 12.04 or later - [Download Linux AppImage](https://downloads.thousandeyes.com/tedit/recorder/ThousandEyesRecorderIDE.AppImage)
 
-New to synthetic scripting? Check out our [Transaction Scripting Guide](https://docs.thousandeyes.com/product-documentation/tests/transaction-scripting-guide).
+New to synthetic scripting? Start by reviewing the ThousandEyes product documentation for [Transaction Tests](https://docs.thousandeyes.com/product-documentation/browser-synthetics/transaction-tests), and the pages under Transaction Scripting Reference (https://docs.thousandeyes.com/product-documentation/browser-synthetics/transaction-tests/transaction-scripting-reference).
 
 ## Resources
 * [Getting Started guide](https://github.com/thousandeyes/transaction-scripting-examples/wiki/Getting-started-with-ThousandEyes-Synthetics).


### PR DESCRIPTION
New to synthetic scripting? Start by reviewing the ThousandEyes product documentation for [Transaction Tests](https://docs.thousandeyes.com/product-documentation/browser-synthetics/transaction-tests), and the pages under Transaction Scripting Reference (https://docs.thousandeyes.com/product-documentation/browser-synthetics/transaction-tests/transaction-scripting-reference).

Reason: the referenced page doesn’t exist. There is no “Transaction Scripting Guide” really. It’s a redirect that points to a placeholder section on the current Transaction Tests landing page. Would be cleaner to point to the landing page and get rid of that placeholder. 

There is a different existing Transaction Scripting Guide page, with relevant information. We should point to that as well. But, if they’re new to scripting altogether, they should start with the transaction test landing page.